### PR TITLE
Fix dependency errors

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM r-base:latest
+FROM r-base:4.5.0
 
 # Set compiler settings
 RUN mkdir $HOME/.R/
@@ -24,6 +24,8 @@ RUN apt-get -y install apt-utils libcurl4-openssl-dev libv8-dev libtbb-dev \
 
 # Install RStan
 RUN R -e "install.packages('rstan', repos = c('https://stan-dev.r-universe.dev', getOption('repos')))"
+# Install httpgd
+RUN R -e "install.packages('httpgd', repos = c('https://community.r-multiverse.org', 'https://cloud.r-project.org'))"
 
 # Install other R packages
 RUN install2.r --error \
@@ -33,7 +35,6 @@ RUN install2.r --error \
     dagitty \
     shape \
     languageserver \
-    httpgd \
     brms
 
 # Install R packages cmdstanr and rethinking from GitHub


### PR DESCRIPTION
Hi, thanks for providing the devcontainer files. I ran into some dependency errors while building the container using the latest `r-base` image (error messages shown below). To reproduce them, you may need to delete your local container image and rebuild. 

This PR addresses those errors. 

1. Conflicting version of `libcurl4`.
```
#0 1.282 The following packages have unmet dependencies:
#0 1.282  libcurl4-openssl-dev : Depends: libcurl4t64 (= 8.15.0-1) but 8.16.0-1 is to be installed
#0 1.289 E: Unable to correct problems, you have held broken packages.
#0 1.289 E: The following information from --solver 3.0 may provide additional context:
#0 1.289    Unable to satisfy dependencies. Reached two conflicting decisions:
#0 1.289    1. libcurl4t64:arm64=8.15.0-1 is not selected for install
#0 1.289    2. libcurl4t64:arm64=8.15.0-1 is selected as a downgrade because:
#0 1.289       1. libcurl4-openssl-dev:arm64=8.15.0-1 is selected for install
#0 1.289       2. libcurl4-openssl-dev:arm64=8.15.0-1 Depends libcurl4t64 (= 8.15.0-1)
```

2. Package `httpgd` not available

```
#0 161.5 package ‘httpgd’ is not available for this version of R
```